### PR TITLE
NetworkImageView's url field access modifier update

### DIFF
--- a/src/com/android/volley/toolbox/NetworkImageView.java
+++ b/src/com/android/volley/toolbox/NetworkImageView.java
@@ -33,7 +33,7 @@ import com.android.volley.toolbox.ImageLoader.ImageListener;
  */
 public class NetworkImageView extends ImageView {
     /** The URL of the network image to load */
-    private String mUrl;
+    protected String mUrl;
 
     /**
      * Resource ID of the image to be used as a placeholder until the network image is loaded.


### PR DESCRIPTION
Updated access modifier of `NetworkImageView.mUrl` from private to protected, so subclass `HaloImageView` can track its state
