### PR TITLE
NETWORK_IF_NO_CACHE cancels request and allows finish() by normal ExecutorDelivery mechanism

### DIFF
--- a/src/com/android/volley/NetworkDispatcher.java
+++ b/src/com/android/volley/NetworkDispatcher.java
@@ -136,7 +136,7 @@ public class NetworkDispatcher extends Thread {
 
                 // Post the response back.
                 if (request.hasHadResponseDelivered() && request.getReturnStrategy() == ReturnStrategy.NETWORK_IF_NO_CACHE) {
-                    continue;
+                    request.cancel();
                 }
                 request.markDelivered();
                 mDelivery.postResponse(request, response);


### PR DESCRIPTION
orDelivery mechanism
