### PR TITLE
Fix Volley to properly encode string response based on header content-type

### DIFF
--- a/src/com/android/volley/toolbox/HttpHeaderParser.java
+++ b/src/com/android/volley/toolbox/HttpHeaderParser.java
@@ -121,6 +121,10 @@ public class HttpHeaderParser {
      */
     public static String parseCharset(Map<String, String> headers) {
         String contentType = headers.get(HTTP.CONTENT_TYPE);
+        if (contentType == null) {
+            // HTTP header names should be case-insensitive, account for lowercase "content-type" as well
+            contentType = headers.get(HTTP.CONTENT_TYPE.toLowerCase());
+        }
         if (contentType != null) {
             String[] params = contentType.split(";");
             for (int i = 1; i < params.length; i++) {


### PR DESCRIPTION
This causes the Google places api response to display unreadable characters sometimes: https://jira.airbnb.com:8443/browse/PRODUCT-6184
