### PR TITLE
save memory with cache headers

### DIFF
--- a/src/com/android/volley/toolbox/DiskBasedCache.java
+++ b/src/com/android/volley/toolbox/DiskBasedCache.java
@@ -442,7 +442,7 @@ public class DiskBasedCache implements Cache {
          * @param is The InputStream to read from.
          * @throws IOException
          */
-        public static CacheHeader readHeader(InputStream is, boolean readFull) throws IOException {
+        public static CacheHeader readHeader(InputStream is, boolean includeResponseHeaders) throws IOException {
             CacheHeader entry = new CacheHeader();
 
             int magic = readInt(is);
@@ -460,7 +460,7 @@ public class DiskBasedCache implements Cache {
             entry.softTtl = readLong(is);
 
             Map<String, String> headers = readStringStringMap(is);
-            if (readFull) {
+            if (includeResponseHeaders) {
                 entry.responseHeaders = headers;
             } else {
                 entry.responseHeaders = new HashMap<>();

--- a/src/com/android/volley/toolbox/DiskBasedCache.java
+++ b/src/com/android/volley/toolbox/DiskBasedCache.java
@@ -240,6 +240,7 @@ public class DiskBasedCache implements Cache {
             }
             fos.write(entry.data);
             fos.close();
+            e.responseHeaders.clear();
             putEntry(key, e);
             return;
         } catch (IOException e) {

--- a/src/com/android/volley/toolbox/DiskBasedCache.java
+++ b/src/com/android/volley/toolbox/DiskBasedCache.java
@@ -260,6 +260,7 @@ public class DiskBasedCache implements Cache {
     private void updateEntrySynchronous(String key, Entry entry) {
         Entry cachedEntry = get(key);
         entry.data = cachedEntry.data;
+        entry.responseHeaders = cachedEntry.responseHeaders;
         put(key, entry, true);
     }
 

--- a/src/com/android/volley/toolbox/DiskBasedCache.java
+++ b/src/com/android/volley/toolbox/DiskBasedCache.java
@@ -240,7 +240,9 @@ public class DiskBasedCache implements Cache {
             }
             fos.write(entry.data);
             fos.close();
-            e.responseHeaders.clear();
+            if (e.responseHeaders != null) {
+                e.responseHeaders.clear();
+            }
             putEntry(key, e);
             return;
         } catch (IOException e) {

--- a/src/com/android/volley/toolbox/DiskBasedCache.java
+++ b/src/com/android/volley/toolbox/DiskBasedCache.java
@@ -461,9 +461,9 @@ public class DiskBasedCache implements Cache {
             entry.ttl = readLong(is);
             entry.softTtl = readLong(is);
 
-            Map<String, String> headers = readStringStringMap(is);
             if (includeResponseHeaders) {
-                entry.responseHeaders = headers;
+                entry.responseHeaders = readStringStringMap(is);
+
             } else {
                 entry.responseHeaders = new HashMap<>();
             }


### PR DESCRIPTION
save a bunch of memory by not parsing all the cache headers up front
@lxdvs 
