### PR TITLE
Get and set listeners

### DIFF
--- a/library/src/main/java/com/android/volley/CacheDispatcher.java
+++ b/library/src/main/java/com/android/volley/CacheDispatcher.java
@@ -137,6 +137,7 @@ public class CacheDispatcher extends Thread {
 
                 if (!entry.refreshNeeded()) {
                     // Completely unexpired cache hit. Just deliver the response.
+                    request.markDelivery(Request.DeliveryType.Cache);
                     mDelivery.postResponse(request, response);
                 } else if (request.getReturnStrategy() == Request.ReturnStrategy.CACHE_IF_NETWORK_FAILS) {
                     // if CACHE_IF_NETWORK_FAILS prep cache response and send to network
@@ -159,6 +160,7 @@ public class CacheDispatcher extends Thread {
 
                     // Post the intermediate response back to the user and have
                     // the delivery then forward the request along to the network if allowed
+                    request.markDelivery(Request.DeliveryType.Cache);
                     mDelivery.postResponse(request, response, cacheOnlyRequest ? null : new Runnable() {
                         @Override
                         public void run() {

--- a/library/src/main/java/com/android/volley/ExecutorDelivery.java
+++ b/library/src/main/java/com/android/volley/ExecutorDelivery.java
@@ -73,7 +73,6 @@ public class ExecutorDelivery implements ResponseDelivery {
             request.addMarker("post-cached-on-error: " + errStr);
             postResponse(request, request.mCacheResponse, null);
         } else {
-            request.markDelivery(Request.DeliveryType.Error);
             request.addMarker("post-error: " + errStr);
             Response<?> response = Response.error(error);
             mResponsePoster.execute(new ResponseDeliveryRunnable(request, response, null));

--- a/library/src/main/java/com/android/volley/ExecutorDelivery.java
+++ b/library/src/main/java/com/android/volley/ExecutorDelivery.java
@@ -60,7 +60,6 @@ public class ExecutorDelivery implements ResponseDelivery {
 
     @Override
     public void postResponse(Request<?> request, Response<?> response, Runnable runnable) {
-        request.markDelivered();
         request.addMarker("post-response");
         mResponsePoster.execute(new ResponseDeliveryRunnable(request, response, runnable));
     }
@@ -70,9 +69,11 @@ public class ExecutorDelivery implements ResponseDelivery {
         String errStr = error == null || error.networkResponse == null || TextUtils.isEmpty(error.networkResponse.errorResponseString) ?
                 "<unparsed>" : error.networkResponse.errorResponseString;
         if (request.getReturnStrategy() == ReturnStrategy.CACHE_IF_NETWORK_FAILS && request.mCacheResponse != null) {
+            request.markDelivery(Request.DeliveryType.Cache);
             request.addMarker("post-cached-on-error: " + errStr);
             postResponse(request, request.mCacheResponse, null);
         } else {
+            request.markDelivery(Request.DeliveryType.Error);
             request.addMarker("post-error: " + errStr);
             Response<?> response = Response.error(error);
             mResponsePoster.execute(new ResponseDeliveryRunnable(request, response, null));

--- a/library/src/main/java/com/android/volley/NetworkDispatcher.java
+++ b/library/src/main/java/com/android/volley/NetworkDispatcher.java
@@ -147,8 +147,10 @@ public class NetworkDispatcher extends Thread {
                 // Post the response back.
                 if (request.hasHadResponseDelivered() && request.getReturnStrategy() == ReturnStrategy.NETWORK_IF_NO_CACHE) {
                     request.cancel();
+                } else {
+                    request.markDelivery(Request.DeliveryType.Network);
                 }
-                request.markDelivered();
+
                 mDelivery.postResponse(request, response);
             } catch (VolleyError volleyError) {
                 if (request.hasHadResponseDelivered() && request.getReturnStrategy() == ReturnStrategy.NETWORK_IF_NO_CACHE) {

--- a/library/src/main/java/com/android/volley/Request.java
+++ b/library/src/main/java/com/android/volley/Request.java
@@ -70,6 +70,10 @@ public abstract class Request<T> implements Comparable<Request<T>> {
         int PATCH = 7;
     }
 
+    public enum DeliveryType {
+        None, Cache, Network, Error;
+    }
+
     /**
      * Supported request methods.
      */
@@ -91,6 +95,8 @@ public abstract class Request<T> implements Comparable<Request<T>> {
 
     protected ReturnStrategy mReturnStrategy = ReturnStrategy.DOUBLE;
 
+    private DeliveryType mResponseDelivery = DeliveryType.None;
+
     /** URL of this request. */
     private final String mUrl;
 
@@ -111,9 +117,6 @@ public abstract class Request<T> implements Comparable<Request<T>> {
 
     /** Whether or not this request has been canceled. */
     private boolean mCanceled = false;
-
-    /** Whether or not a response has been delivered for this request yet. */
-    private boolean mResponseDelivered = false;
 
     // A cheap variant of request tracing used to dump slow requests.
     private long mRequestBirthTime = 0;
@@ -583,8 +586,8 @@ public abstract class Request<T> implements Comparable<Request<T>> {
      * Mark this request as having a response delivered on it.  This can be used
      * later in the request's lifetime for suppressing identical responses.
      */
-    public void markDelivered() {
-        mResponseDelivered = true;
+    public void markDelivery(DeliveryType type) {
+        mResponseDelivery = type;
     }
 
     public Response<?> mCacheResponse;
@@ -593,7 +596,11 @@ public abstract class Request<T> implements Comparable<Request<T>> {
      * Returns true if this request has had a response delivered for it.
      */
     public boolean hasHadResponseDelivered() {
-        return mResponseDelivered;
+        return mResponseDelivery == DeliveryType.Cache || mResponseDelivery == DeliveryType.Network;
+    }
+
+    public DeliveryType getDeliveryType() {
+        return mResponseDelivery;
     }
 
     /**

--- a/library/src/main/java/com/android/volley/Request.java
+++ b/library/src/main/java/com/android/volley/Request.java
@@ -71,7 +71,7 @@ public abstract class Request<T> implements Comparable<Request<T>> {
     }
 
     public enum DeliveryType {
-        None, Cache, Network, Error;
+        None, Cache, Network
     }
 
     /**
@@ -95,6 +95,11 @@ public abstract class Request<T> implements Comparable<Request<T>> {
 
     protected ReturnStrategy mReturnStrategy = ReturnStrategy.DOUBLE;
 
+    /**
+     * Track if a response has been delivered, as well as the type (cache or network) of the most recent response.
+     * Only the most recent delivery type is remembered, so if a cache and network response are both delivered
+     * this will be the second response type.
+     */
     private DeliveryType mResponseDelivery = DeliveryType.None;
 
     /** URL of this request. */
@@ -583,8 +588,10 @@ public abstract class Request<T> implements Comparable<Request<T>> {
     }
 
     /**
-     * Mark this request as having a response delivered on it.  This can be used
-     * later in the request's lifetime for suppressing identical responses.
+     * Mark this request as having a response delivered on it, as well as the type of response.  This can be used
+     * later in the request's lifetime for suppressing identical responses and identifying whether the response
+     * came from cache or network. This will be set immediately before {@link #deliverResponse(Object)} is called
+     * so the {@link com.android.volley.Request.DeliveryType} can be checked at the time of delivery.
      */
     public void markDelivery(DeliveryType type) {
         mResponseDelivery = type;
@@ -592,13 +599,18 @@ public abstract class Request<T> implements Comparable<Request<T>> {
 
     public Response<?> mCacheResponse;
 
-    /**
-     * Returns true if this request has had a response delivered for it.
+    /**t
+     * Returns true if this request has had either a cache or network response delivered for it.
      */
     public boolean hasHadResponseDelivered() {
-        return mResponseDelivery == DeliveryType.Cache || mResponseDelivery == DeliveryType.Network;
+        return mResponseDelivery != DeliveryType.None;
     }
 
+    /**
+     * If {@link #hasHadResponseDelivered()} is true this will return the most recent type of response delivered,
+     * otherwise this will return {@link com.android.volley.Request.DeliveryType#None}.
+     * @return
+     */
     public DeliveryType getDeliveryType() {
         return mResponseDelivery;
     }

--- a/library/src/main/java/com/android/volley/Request.java
+++ b/library/src/main/java/com/android/volley/Request.java
@@ -98,7 +98,7 @@ public abstract class Request<T> implements Comparable<Request<T>> {
     private final int mDefaultTrafficStatsTag;
 
     /** Listener interface for errors. */
-    private final Response.ErrorListener mErrorListener;
+    private Response.ErrorListener mErrorListener;
 
     /** Sequence number of this request, used to enforce FIFO ordering. */
     private Integer mSequence;
@@ -197,6 +197,10 @@ public abstract class Request<T> implements Comparable<Request<T>> {
      */
     public Response.ErrorListener getErrorListener() {
         return mErrorListener;
+    }
+
+    public void setErrorListener(Response.ErrorListener errorListener) {
+        mErrorListener = errorListener;
     }
 
     /**

--- a/library/src/main/java/com/android/volley/Request.java
+++ b/library/src/main/java/com/android/volley/Request.java
@@ -599,7 +599,7 @@ public abstract class Request<T> implements Comparable<Request<T>> {
 
     public Response<?> mCacheResponse;
 
-    /**t
+    /**
      * Returns true if this request has had either a cache or network response delivered for it.
      */
     public boolean hasHadResponseDelivered() {

--- a/library/src/main/java/com/android/volley/Request.java
+++ b/library/src/main/java/com/android/volley/Request.java
@@ -70,8 +70,14 @@ public abstract class Request<T> implements Comparable<Request<T>> {
         int PATCH = 7;
     }
 
+    /** Track the type of response being delivered. */
     public enum DeliveryType {
-        None, Cache, Network
+        /** No responses have been delivered so far */
+        None,
+        /** A cache response was delivered. */
+        Cache,
+        /** A network response was delivered. */
+        Network
     }
 
     /**
@@ -603,7 +609,7 @@ public abstract class Request<T> implements Comparable<Request<T>> {
      * Returns true if this request has had either a cache or network response delivered for it.
      */
     public boolean hasHadResponseDelivered() {
-        return mResponseDelivery != DeliveryType.None;
+        return mResponseDelivery == DeliveryType.Network || mResponseDelivery == DeliveryType.Cache;
     }
 
     /**


### PR DESCRIPTION
Allow request listeners to be accessed and changed after the request is constructed. This allows the request manager to intercept the request and replace the initial listener.

This also changes "markDelivery" to specify the type of delivery - cache, network, or error - so we can know where the delivered response is coming from.
