### PR TITLE
prevent abstract exception from adding all headers in basic network

### DIFF
--- a/library/src/main/java/com/android/volley/Cache.java
+++ b/library/src/main/java/com/android/volley/Cache.java
@@ -16,7 +16,7 @@
 
 package com.android.volley;
 
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -101,7 +101,7 @@ public interface Cache {
         public long softTtl;
 
         /** Immutable response headers as received from server; must be non-null. */
-        public Map<String, String> responseHeaders = Collections.emptyMap();
+        public Map<String, String> responseHeaders = new HashMap<>();
 
         /** True if the entry is expired. */
         public boolean isExpired() {


### PR DESCRIPTION
@carolineleung @lxdvs @elihart 
fix abstract exception 
https://github.com/lxdvs/Volley-OkHttp-Android/blob/bnb/library/src/main/java/com/android/volley/toolbox/BasicNetwork.java#L115
